### PR TITLE
Pull Request: Add script for downloading a subset benchmark dataset from huggingface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,22 @@ Install the dependencies for the server and the task generation
 pip3 install -e '.[dev,server]'
 ```
 
-Download the benchmark data
-```bash
-git lfs install
-git clone https://huggingface.co/datasets/sunblaze-ucb/cybergym cybergym_data
-```
-
-
-### Download Server Data
+### Download Data
+#### 1. Full data
 Download the PoC submission server data
-1. Full data
 ```bash
 python scripts/server_data/download.py --tasks-file ./cybergym_data/tasks.json
 bash scripts/server_data/download_chunks.sh
 7z x cybergym-oss-fuzz-data.7z
 ```
 
-2. Subset data
+Download the full benchmark data
+```bash
+git lfs install
+git clone https://huggingface.co/datasets/sunblaze-ucb/cybergym cybergym_data
+```
+
+#### 2. Subset data
 
 The full server data is large (~10TB). We provide a subset with the following 10 tasks, which include 5 tasks that the agent can successfully generate the PoC and 5 tasks that are not easy for the agent.
 ```
@@ -46,11 +45,16 @@ oss-fuzz:42535468
 oss-fuzz:370689421
 oss-fuzz:385167047
 ```
-Download the subset data
+Download the subset server data
 ```bash
 python scripts/server_data/download_subset.py
 wget https://huggingface.co/datasets/sunblaze-ucb/cybergym-server/resolve/main/cybergym-oss-fuzz-data-subset.7z
 7z x cybergym-oss-fuzz-data-subset.7z
+```
+
+Download the subset benchmark data
+```bash
+python scripts/download_subset_from_hf.py --data-dir cybergym_data
 ```
 
 ## Evaluation

--- a/scripts/download_subset_from_hf.py
+++ b/scripts/download_subset_from_hf.py
@@ -1,9 +1,3 @@
-"""
-Script to download a subset of datasets from the HuggingFace Hub and organize them into a local data directory structure for cybergym.
-
-Downloads task metadata and dataset files, then moves them into the specified directory, cleaning up cache files.
-"""
-
 import argparse
 from huggingface_hub import hf_hub_download
 import shutil
@@ -62,7 +56,9 @@ def main():
         for folder in folders:
             for file in file_names:
                 remote_path = f"data/{dataset}/{folder}/{file}"
-                local_path = os.path.join(data_dir, dataset, folder, file)
+                local_path = os.path.join(
+                    data_dir, "data", dataset, folder, file
+                )
                 print(f"[{dataset}] Downloading {remote_path} ...")
                 try:
                     src = hf_hub_download(

--- a/scripts/download_subset_from_hf.py
+++ b/scripts/download_subset_from_hf.py
@@ -1,0 +1,80 @@
+"""
+Script to download a subset of datasets from the HuggingFace Hub and organize them into a local data directory structure for cybergym.
+
+Downloads task metadata and dataset files, then moves them into the specified directory, cleaning up cache files.
+"""
+
+import argparse
+from huggingface_hub import hf_hub_download
+import shutil
+import os
+
+
+def move_file(src_path, dest_path):
+    """Move a file from src_path to dest_path and delete the source file.
+
+    Args:
+        src_path (str): The path of the source file.
+        dest_path (str): The path of the destination file.
+    """
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    shutil.copy2(src_path, dest_path)
+    try:
+        os.remove(src_path)
+    except Exception as e:
+        print(f"  Warning: Could not delete cache file {src_path}: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download datasets from HuggingFace and organize them into a specified data directory."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default="cybergym_data",
+        help="Name of the data directory (default: cybergym_data)",
+    )
+    args = parser.parse_args()
+    data_dir = args.data_dir
+
+    repo_id = "sunblaze-ucb/cybergym"
+    dataset_to_folder = {
+        "arvo": ["3938", "24993", "1065", "10400", "368"],
+        "oss-fuzz": ["42535201", "42535468", "370689421", "385167047"],
+    }
+
+    file_names = [
+        "description.txt",
+        "error.txt",
+        "patch.diff",
+        "repo-fix.tar.gz",
+        "repo-vul.tar.gz",
+    ]
+
+    # Download root tasks.json to current directory and delete cache
+    src = hf_hub_download(
+        repo_id=repo_id, repo_type="dataset", filename="tasks.json"
+    )
+    move_file(src, f"{data_dir}/tasks.json")
+
+    for dataset, folders in dataset_to_folder.items():
+        for folder in folders:
+            for file in file_names:
+                remote_path = f"data/{dataset}/{folder}/{file}"
+                local_path = os.path.join(data_dir, dataset, folder, file)
+                print(f"[{dataset}] Downloading {remote_path} ...")
+                try:
+                    src = hf_hub_download(
+                        repo_id=repo_id,
+                        repo_type="dataset",
+                        filename=remote_path,
+                    )
+                    print(f"  Success: {src} -> {local_path}")
+                    move_file(src, local_path)
+                except Exception as e:
+                    print(f"  Failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_subset_from_hf.py
+++ b/scripts/download_subset_from_hf.py
@@ -1,3 +1,9 @@
+"""
+Script to download a subset of datasets from the HuggingFace Hub and organize them into a local data directory structure for cybergym.
+
+Downloads task metadata and dataset files, then moves them into the specified directory, cleaning up cache files.
+"""
+
 import argparse
 from huggingface_hub import hf_hub_download
 import shutil


### PR DESCRIPTION
## Download Subset of Benchmark Data

For users who want to quickly test with subset data, there is already a script for downloading a subset of the **server data**, but not for the benchmark data.

This PR adds `scripts/download_subset_from_hf.py`, which allows you to download only selected tasks from the Hugging Face benchmark dataset.

**Usage:**
```bash
python scripts/download_subset_from_hf.py
````

The script downloads the same 10 tasks as the subset server data.