### PR TITLE
Support rootless podman via a Docker-compatible client helper

### DIFF
--- a/src/cybergym/firewall/proxy.py
+++ b/src/cybergym/firewall/proxy.py
@@ -47,7 +47,7 @@ from pathlib import Path
 
 from docker.errors import APIError, NotFound
 
-import docker
+from cybergym.utils import get_docker_client
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +145,7 @@ class FirewallProxyManager:
         self.proxy_port = proxy_port
         self.container_name = container_name
         self.network_name = network_name
-        self._client = docker.from_env()
+        self._client = get_docker_client()
 
     # -- public API ----------------------------------------------------------
 

--- a/src/cybergym/server/server_utils.py
+++ b/src/cybergym/server/server_utils.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Literal
 from uuid import uuid4
 
-import docker
 import requests
 from docker.errors import DockerException
 from fastapi import HTTPException
@@ -17,7 +16,7 @@ from cybergym.server.pocdb import PoCRecord, get_or_create_poc, get_poc_by_hash,
 from cybergym.server.types import Payload, server_conf
 from cybergym.task.mask import _reverse_map, unmask_task_id
 from cybergym.task.types import verify_task
-from cybergym.utils import get_arvo_id, get_oss_fuzz_id
+from cybergym.utils import get_arvo_id, get_docker_client, get_oss_fuzz_id
 
 FLAG = "flag{3xpl017_cyb3r6ym}"
 DEFAULT_DOCKER_TIMEOUT = 60  # seconds for docker container to run
@@ -76,7 +75,7 @@ def run_container(
 ):
     image, cmd = _image_and_command_from_task_id(task_id, mode)
     cmd = ["/bin/bash", "-c", f"timeout -s SIGKILL {cmd_timeout} {shlex.join(cmd)} 2>&1"]
-    client = docker.from_env()
+    client = get_docker_client()
     container = None
     try:
         # Split create + start so we always have a container ref for cleanup.
@@ -117,7 +116,7 @@ def run_container_binary(
     docker_timeout: int = DEFAULT_DOCKER_TIMEOUT,
     cmd_timeout: int = DEFAULT_CMD_TIMEOUT,
 ):
-    client = docker.from_env()
+    client = get_docker_client()
     subset, subid = task_id.split(":")
     cmd: list[str]
     volumes: dict[str, dict[str, str]]

--- a/src/cybergym/utils.py
+++ b/src/cybergym/utils.py
@@ -1,3 +1,6 @@
+import os
+from pathlib import Path
+
 from pydantic_core import to_json
 
 
@@ -15,3 +18,27 @@ def get_arvo_id(task_id: str):
 
 def get_oss_fuzz_id(task_id: str):
     return task_id.split(":")[1]
+
+
+def get_docker_client():
+    """Return a Docker API client, transparently supporting rootless podman.
+
+    Resolution order:
+
+    1. ``$DOCKER_HOST`` if set (``docker.from_env`` honors it verbatim).
+    2. The default Docker socket at ``/var/run/docker.sock`` if it exists.
+    3. A rootless podman socket at ``$XDG_RUNTIME_DIR/podman/podman.sock``
+       (podman serves a Docker-compatible API there), so the same code runs
+       unchanged under podman.
+
+    Otherwise fall back to ``docker.from_env`` so its usual connection error
+    surfaces.
+    """
+    import docker
+
+    if not os.environ.get("DOCKER_HOST") and not Path("/var/run/docker.sock").exists():
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+        podman_sock = Path(runtime_dir) / "podman" / "podman.sock"
+        if podman_sock.exists():
+            return docker.DockerClient(base_url=f"unix://{podman_sock}", version="auto")
+    return docker.from_env()


### PR DESCRIPTION
## Motivation

cybergym reaches the container runtime through `docker.from_env()`, which only locates a Docker daemon. On hosts running **rootless podman** there is no Docker socket at the default path, so `cybergym.server` (running PoCs) and the firewall proxy fail to connect to the runtime. Today users have to manually export `DOCKER_HOST` pointing at podman's socket.

## Change

Add `cybergym.utils.get_docker_client()`, which resolves the container API endpoint as:

1. `$DOCKER_HOST` if set (honored verbatim by `docker.from_env`)
2. `/var/run/docker.sock` if present (standard Docker)
3. `$XDG_RUNTIME_DIR/podman/podman.sock` — podman serves a **Docker-compatible API** there, so the same code runs unchanged under rootless podman

falling back to `docker.from_env()` otherwise (so its usual connection error still surfaces).

The three `docker.from_env()` call sites are routed through it:
- `server/server_utils.py` — `run_container`, `run_container_binary`
- `firewall/proxy.py` — `FirewallProxyManager.__init__`

## Notes

- **Non-breaking for Docker users**: with no podman socket (or with `DOCKER_HOST`/`/var/run/docker.sock` present) the behavior is identical to `docker.from_env()`.
- The `docker` import inside the helper is **lazy**, so `cybergym.utils` (e.g. `get_arvo_id`) stays importable without the optional `docker` dependency installed.
- `+32 / -6` across 3 files; passes the repo's `ruff` config.
- Verified the resolution branches locally (DOCKER_HOST set → `from_env`; rootless podman socket present → `DockerClient(unix://…/podman.sock)`; nothing present → `from_env` fallback).