### PR TITLE
fix: consistently use absolute paths for the binary containers

### DIFF
--- a/src/cybergym/server/server_utils.py
+++ b/src/cybergym/server/server_utils.py
@@ -146,7 +146,7 @@ def run_container_binary(
             },
         }
         for file in (bin_dir / "out").iterdir():
-            volumes[str(file.absolute())] = {
+            volumes[str(file)] = {
                 "bind": f"/out/{file.name}",
                 "mode": "ro",
             }
@@ -162,7 +162,7 @@ def run_container_binary(
         fuzzer_name = metadata["fuzz_target"]
         volumes = {str(poc_path): {"bind": "/testcase", "mode": "ro"}}
         for subfile in out_dir.iterdir():
-            host_path = str(subfile.absolute())
+            host_path = str(subfile)
             container_path = os.path.join("/out", subfile.name)
             volumes[host_path] = {"bind": container_path, "mode": "ro"}
         cmd = ["reproduce", fuzzer_name]

--- a/src/cybergym/server/server_utils.py
+++ b/src/cybergym/server/server_utils.py
@@ -123,6 +123,8 @@ def run_container_binary(
     volumes: dict[str, dict[str, str]]
     runner_image: str = DEFAULT_RUNNER_IMAGE
     container = None
+    poc_path = poc_path.absolute()
+    data_dir = data_dir.absolute()
 
     if subset == "arvo":
         runner_image_file = data_dir / "arvo" / subid / mode / "runner"
@@ -130,15 +132,15 @@ def run_container_binary(
             runner_image = runner_image_file.read_text().strip()
         bin_dir = data_dir / "arvo" / subid / mode
         volumes = {
-            str((bin_dir / "arvo").absolute()): {
+            str(bin_dir / "arvo"): {
                 "bind": "/arvo",
                 "mode": "ro",
             },
-            str(poc_path.absolute()): {
+            str(poc_path): {
                 "bind": "/tmp/poc",  # noqa: S108
                 "mode": "ro",
             },
-            str((bin_dir / "libs").absolute()): {
+            str(bin_dir / "libs"): {
                 "bind": "/out-libs",
                 "mode": "ro",
             },
@@ -158,7 +160,7 @@ def run_container_binary(
         with open(meta_file) as f:
             metadata = json.load(f)
         fuzzer_name = metadata["fuzz_target"]
-        volumes = {str(poc_path.absolute()): {"bind": "/testcase", "mode": "ro"}}
+        volumes = {str(poc_path): {"bind": "/testcase", "mode": "ro"}}
         for subfile in out_dir.iterdir():
             host_path = str(subfile.absolute())
             container_path = os.path.join("/out", subfile.name)

--- a/src/cybergym/server/server_utils.py
+++ b/src/cybergym/server/server_utils.py
@@ -130,7 +130,7 @@ def run_container_binary(
             runner_image = runner_image_file.read_text().strip()
         bin_dir = data_dir / "arvo" / subid / mode
         volumes = {
-            str(bin_dir / "arvo"): {
+            str((bin_dir / "arvo").absolute()): {
                 "bind": "/arvo",
                 "mode": "ro",
             },
@@ -138,13 +138,13 @@ def run_container_binary(
                 "bind": "/tmp/poc",  # noqa: S108
                 "mode": "ro",
             },
-            str(bin_dir / "libs"): {
+            str((bin_dir / "libs").absolute()): {
                 "bind": "/out-libs",
                 "mode": "ro",
             },
         }
         for file in (bin_dir / "out").iterdir():
-            volumes[str(file)] = {
+            volumes[str(file.absolute())] = {
                 "bind": f"/out/{file.name}",
                 "mode": "ro",
             }


### PR DESCRIPTION
# Issue

When attempting to run the PoC submission server in binary only mode, I would get the following error:
```
Client Error for http+docker://localhost/v1.55/containers/create: Bad Request ("create cybergym-server-data/arvo/10400/vul/arvo: "cybergym-server-data/arvo/10400/vul/arvo" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
```

This comes from the inconstant use of absolute paths in the `run_container_binary` function in `src/cybergym/server/server_utils.py`.

# Changes

Now all paths used in container volumes in the  `run_container_binary` function are converted to absolute paths before conversion to strings.